### PR TITLE
Fix default value for redirect select

### DIFF
--- a/src/Nova/Redirect.php
+++ b/src/Nova/Redirect.php
@@ -31,7 +31,7 @@ class Redirect extends Resource {
                 '304' => '304 (Not Modified)',
                 '307' => '307 (Temporary Redirect)',
                 '308' => '308 (Permanent Redirect)'
-            ])->rules('required')->withMeta(['value' => '302'])
+            ])->rules('required')->withMeta(['value' => $this->status_code ?: '302'])
         ];
     }
 

--- a/src/Nova/Redirect.php
+++ b/src/Nova/Redirect.php
@@ -31,7 +31,7 @@ class Redirect extends Resource {
                 '304' => '304 (Not Modified)',
                 '307' => '307 (Temporary Redirect)',
                 '308' => '308 (Permanent Redirect)'
-            ])->rules('required')->withMeta(['value' => $this->status_code ?: '302'])
+            ])->rules('required')->default('302')
         ];
     }
 


### PR DESCRIPTION
Using `->withMeta(['value' => '302'])` will display only `302` on edit, detail and index regardless of what is actually saved in the database. This fix uses `302` or the actual value.

